### PR TITLE
[#33] fix resizing issues

### DIFF
--- a/src/view/ui.py
+++ b/src/view/ui.py
@@ -119,6 +119,7 @@ class QViewWidget(QtWidgets.QWidget):
         # add size gripto footer  if rezizable
         if resizable:
             self.sizeGrip = QtWidgets.QSizeGrip(self)
+            self.sizeGrip.mouseMoveEvent = self._mouseMoveEvent
             hbox.addWidget(self.sizeGrip)
 
         vbox.addWidget(QtWidgets.QWidget())
@@ -137,6 +138,9 @@ class QViewWidget(QtWidgets.QWidget):
 
         self.proxy = QtWidgets.QGraphicsProxyWidget(self.handle)
         self.proxy.setWidget(self)
+
+    def _mouseMoveEvent(self, event):
+        self.resize(self.width()+event.pos().x(), 0)
 
     def setWidget(self, widget):
         """

--- a/src/view/ui.py
+++ b/src/view/ui.py
@@ -140,7 +140,7 @@ class QViewWidget(QtWidgets.QWidget):
         self.proxy.setWidget(self)
 
     def _mouseMoveEvent(self, event):
-        self.resize(self.width()+event.pos().x(), 0)
+        self.resize(self.width()+event.pos().x(), self.height()+event.pos().y())
 
     def setWidget(self, widget):
         """

--- a/src/view/ui/Graph.ui
+++ b/src/view/ui/Graph.ui
@@ -31,11 +31,23 @@
    </property>
    <item>
     <widget class="QGraphicsView" name="view">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
      <property name="frameShape">
       <enum>QFrame::Box</enum>
      </property>
      <property name="frameShadow">
       <enum>QFrame::Sunken</enum>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
      </property>
      <property name="backgroundBrush">
       <brush brushstyle="CrossPattern">
@@ -61,8 +73,14 @@
      <property name="cacheMode">
       <set>QGraphicsView::CacheNone</set>
      </property>
-     <property name="resizeAnchor">
+     <property name="transformationAnchor">
       <enum>QGraphicsView::NoAnchor</enum>
+     </property>
+     <property name="resizeAnchor">
+      <enum>QGraphicsView::AnchorViewCenter</enum>
+     </property>
+     <property name="rubberBandSelectionMode">
+      <enum>Qt::IntersectsItemShape</enum>
      </property>
     </widget>
    </item>

--- a/src/view/ui/Node.ui
+++ b/src/view/ui/Node.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>206</width>
-    <height>76</height>
+    <width>187</width>
+    <height>48</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -54,14 +54,14 @@
        </property>
       </layout>
      </item>
-     <item>
+     <item alignment="Qt::AlignTop">
       <widget class="QLabel" name="snap">
        <property name="enabled">
         <bool>true</bool>
        </property>
        <property name="minimumSize">
         <size>
-         <width>198</width>
+         <width>1</width>
          <height>0</height>
         </size>
        </property>


### PR DESCRIPTION
The default QSIzeGrip resizing  functions seems to be in conflict with other functions. And we couldn't resize a node if the mouse get out of the qgraphics view. 
Now we are able to resize nodes as we want.